### PR TITLE
Add docker debugging script and instructions.

### DIFF
--- a/docker-debug.sh
+++ b/docker-debug.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+#  This script is the ENTRYPOINT for the docker container; it starts a Redis daemon and
+#  fires up node inspector for debugging.
+#
+
+# Add the plotting and extractor paths to python
+export PYTHONPATH="$PYTHONPATH:/app/GISportal/plotting:/app/GISportal/plotting/data_extractor"
+
+# build the app from the source files
+cd /app/GISportal
+grunt
+
+npm -g install node-inspector
+
+#start redis
+/usr/bin/redis-server --daemonize yes;
+
+# start the app
+node-debug --web-host 0.0.0.0 /app/GISportal/app.js

--- a/docker-readme.md
+++ b/docker-readme.md
@@ -36,8 +36,20 @@
     docker run -d -p 6789:6789 -v /usr/share/GISportal:/app/GISportal/config -t pmlrsg/gisportal
     ```
 
+## Debugging GISportal
+
+To debug the node server inside the docker container run:
+
+```
+docker run -p 6789:6789 -p 8080:8080 -v /home/cpa/workspace/gisportal-docker-config-sub:/app/GISportal/config -it 30904 /app/GISportal/docker-debug.sh
+```
+
+Which starts the [node-inspector](https://github.com/node-inspector/node-inspector) for the
+GISportal. The debugging tools can be accessed under http://localhost:8080/?port=5858 .
+
+
 ## Running GISportal with nginx ##
-  
+
 You can run a standard installation of nginx and use the `proxy_pass` command to proxy requests to your GISportal container running on port 6789; see the main README.md for details. Alternatively, you can use an nginx docker container using the following commands:
 
 ```


### PR DESCRIPTION
It would be faster to install node-inspector in the dockerfile but I did not want to dirty the container. Could also be done with an environment variable see -> http://stackoverflow.com/questions/32982391/debug-nodejs-inside-docker-container?lq=1