### PR TITLE
Enable scatter plotting in case the two variables have the same name.

### DIFF
--- a/plotting/data_extractor/analysis_types/scatter_stats.py
+++ b/plotting/data_extractor/analysis_types/scatter_stats.py
@@ -4,13 +4,21 @@ import json
 
 class ScatterStats(object):
 	"""docstring for BasicStats"""
-	def __init__(self, filenames):
+	def __init__(self, variables, filenames):
+        """
+        Parameters
+        ----------
+        variables: list
+            list of variables to extract from the filenames
+        filenames: list
+            list of filenames from which to extract the variables
+        """
 		super(ScatterStats, self).__init__()
 		
 		
-		self.variable1, self.variable2 = filenames.keys()
-		self.filename1 = filenames[self.variable1]
-		self.filename2 = filenames[self.variable2]
+		self.variable1, self.variable2 = variables[0], variables[1]
+		self.filename1 = filenames[0]
+		self.filename2 = filenames[1]
 
 	def process(self):
 		print "running basic processing on %s & %s" % (self.filename1, self.filename2)

--- a/plotting/plots.py
+++ b/plotting/plots.py
@@ -1575,7 +1575,8 @@ def get_plot_data(json_request, plot=dict(), download_dir="/tmp/"):
          update_status(dirname, my_hash, Plot_status.extracting, percentage=90/len(series))
    elif plot_type == "scatter":
       t_holder = {}
-      scatter_stats_holder = {}
+      scatter_stats_fnames = []
+      scatter_stats_variables = []
       series_count = 0
       for s in series:
          ds = s['data_source']
@@ -1605,7 +1606,8 @@ def get_plot_data(json_request, plot=dict(), download_dir="/tmp/"):
             else:
                extractor = BasicExtractor(ds['threddsUrl'], time_bounds, extract_area=bbox, extract_variable=coverage, extract_depth=depth, outdir=download_dir)
             extract = extractor.getData()
-            scatter_stats_holder[coverage] = extract
+            scatter_stats_variables.append(coverage)
+            scatter_stats_fnames.append(extract)
          except ValueError:
             debug(2, u"Data request, {}, failed".format(data_request))
             return dict(data=[])
@@ -1615,7 +1617,8 @@ def get_plot_data(json_request, plot=dict(), download_dir="/tmp/"):
          except requests.exceptions.ReadTimeout:
             debug(2, u"Data request, {}, failed".format(data_request))
             return dict(data=[])
-      stats = ScatterStats(scatter_stats_holder)
+      stats = ScatterStats(scatter_stats_variables,
+                           scatter_stats_fnames)
       response = json.loads(stats.process())
       data = response['data']
       data_order = response['order']


### PR DESCRIPTION
The problem with the existing dictionary approach occurs when trying to scatterplot two datasets in which the variables have the same name. 